### PR TITLE
add authorizedRequest handler

### DIFF
--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -1,8 +1,31 @@
+import {obj} from "./extra/types";
+
 export class BadResponse extends Error {
     response
     constructor(response, message = 'Bad Response') {
         super(message);
         this.response = response
+    }
+}
+
+export class MalformedResponse extends Error {
+    response
+    missingData
+    constructor(response, missingData) {
+        super('Malformed Response');
+        this.response = response
+        this.missingData = missingData
+    }
+}
+
+export class BadJSONResponse extends BadResponse {
+    constructor(
+        response: Response,
+        public data,
+        public checkedField: string,
+        public successValues: obj
+    ) {
+        super(response, 'Json Response does not indicates success');
     }
 }
 


### PR DESCRIPTION
add authorizerRequest() handler as an alternative to startCookiesRefreshInterval()
also reduce jwt expiration checks performance penalty, by ditching decodeJwt() step

i don't really like an idea of checking token expiration on every request knowing 99.99% times it is not expired,
i thought about monkeypathing this function to redirect to request() when we are sure know token is not expired, but it is also creates performance and usability problems...